### PR TITLE
Implement and use malloc wrapper which aborts on failure

### DIFF
--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -45,4 +45,12 @@
  */
 cfe_error cfe_init(void);
 
+/**
+ * Malloc wrapper which aborts on failure (out-of-memory error).
+ *
+ * @param size Size of memory block
+ * @return Pointer to allocated memory
+ */
+void *cfe_malloc(size_t size);
+
 #endif

--- a/src/data/mat.c
+++ b/src/data/mat.c
@@ -30,12 +30,13 @@
 #include <assert.h>
 
 #include "data/mat.h"
+#include "internal/common.h"
 
 // Initializes a matrix.
 void cfe_mat_init(cfe_mat *m, size_t rows, size_t cols) {
     m->rows = rows;
     m->cols = cols;
-    m->mat = (cfe_vec *) malloc(rows * sizeof(cfe_vec));
+    m->mat = (cfe_vec *) cfe_malloc(rows * sizeof(cfe_vec));
 
     for (size_t i = 0; i < rows; i++) {
         cfe_vec_init(&m->mat[i], cols);

--- a/src/data/vec.c
+++ b/src/data/vec.c
@@ -31,11 +31,12 @@
 
 #include "data/vec.h"
 #include "data/mat.h"
+#include "internal/common.h"
 
 // Initializes a vector.
 void cfe_vec_init(cfe_vec *v, size_t size) {
     v->size = size;
-    v->vec = (mpz_t *) malloc(size * sizeof(mpz_t));
+    v->vec = (mpz_t *) cfe_malloc(size * sizeof(mpz_t));
 
     for (size_t i = 0; i < size; i++) {
         mpz_init(v->vec[i]);

--- a/src/data/vec_float.c
+++ b/src/data/vec_float.c
@@ -27,12 +27,14 @@
 
 #include <stdlib.h>
 #include <assert.h>
+
 #include "data/vec_float.h"
+#include "internal/common.h"
 
 // Initializes a vector.
 void cfe_vec_float_init(cfe_vec_float *v, size_t size, size_t prec) {
     v->size = size;
-    v->vec = (mpf_t *) malloc(size * sizeof(mpf_t));
+    v->vec = (mpf_t *) cfe_malloc(size * sizeof(mpf_t));
 
     for (size_t i = 0; i < size; i++) {
         mpf_init2(v->vec[i], prec);

--- a/src/innerprod/fullysec/damgard_multi.c
+++ b/src/innerprod/fullysec/damgard_multi.c
@@ -26,8 +26,9 @@
  */
 
 #include <stdlib.h>
-#include "innerprod/fullysec/damgard_multi.h"
 
+#include "innerprod/fullysec/damgard_multi.h"
+#include "internal/common.h"
 #include "sample/uniform.h"
 
 cfe_error cfe_damgard_multi_init(cfe_damgard_multi *m, size_t slots, size_t l, size_t modulus_len, mpz_t bound) {
@@ -77,7 +78,7 @@ void cfe_damgard_multi_fe_key_free(cfe_damgard_multi_fe_key *key) {
 }
 
 void cfe_damgard_multi_generate_master_keys(cfe_mat *mpk, cfe_damgard_multi_sec_key *msk, cfe_damgard_multi *m) {
-    msk->msk = malloc(sizeof(cfe_damgard_sec_key) * m->slots);
+    msk->msk = cfe_malloc(sizeof(cfe_damgard_sec_key) * m->slots);
     msk->num_keys = m->slots;
     cfe_mat_inits(m->slots, m->scheme.l, mpk, &msk->otp, NULL);
 

--- a/src/internal/common.c
+++ b/src/internal/common.c
@@ -35,3 +35,14 @@ cfe_error cfe_init(void) {
     }
     return CFE_ERR_NONE;
 }
+
+void *cfe_malloc(size_t size) {
+    void *ptr = malloc(size);
+
+    if (size != 0 && ptr == NULL) {
+        perror("Failed to allocate memory");
+        abort();
+    }
+
+    return ptr;
+}

--- a/src/internal/dlog.c
+++ b/src/internal/dlog.c
@@ -28,7 +28,9 @@
 #include <stdlib.h>
 #include <uthash.h>
 #include <gmp.h>
-#include <internal/errors.h>
+
+#include "internal/common.h"
+#include "internal/errors.h"
 #include "internal/dlog.h"
 
 typedef struct bigint_hash {
@@ -71,7 +73,7 @@ cfe_error cfe_baby_giant(mpz_t res, mpz_t h, mpz_t g, mpz_t p, mpz_t _order, mpz
         // store T[x] = i
         // create a struct t and store the key and value
         // the key is actually the internal contents of a mpz_t, the array and the minimal possible length
-        t = (bigint_hash *) malloc(sizeof(bigint_hash));
+        t = (bigint_hash *) cfe_malloc(sizeof(bigint_hash));
         mpz_init_set(t->key, x);
         mpz_init_set(t->val, i);
 

--- a/src/internal/prime.c
+++ b/src/internal/prime.c
@@ -29,6 +29,7 @@
 #include <stdlib.h>
 #include <sodium.h>
 
+#include "internal/common.h"
 #include "internal/prime.h"
 
 // Checks if p is a safe prime, e.g. if (p-1)/2 is also a prime.
@@ -69,7 +70,7 @@ cfe_error cfe_get_prime(mpz_t res, size_t bits, bool safe) {
     // the safe prime will have the correct amount of bits
     size_t n_bits = safe ? bits - 1 : bits;
     size_t n_bytes = (bits + 7) / 8;
-    uint8_t *bytes = (uint8_t *) malloc(n_bytes * sizeof(uint8_t));
+    uint8_t *bytes = (uint8_t *) cfe_malloc(n_bytes * sizeof(uint8_t));
 
     size_t b = n_bits % 8;
     if (b == 0) {

--- a/src/sample/uniform.c
+++ b/src/sample/uniform.c
@@ -27,6 +27,7 @@
 
 #include <sodium.h>
 
+#include "internal/common.h"
 #include "sample/uniform.h"
 
 bool cfe_bit_sample(void) {
@@ -37,7 +38,7 @@ void cfe_uniform_sample(mpz_t res, mpz_t upper) {
     // determine the size of buffer to read random bytes in and allocate it
     size_t n_bits = mpz_sizeinbase(upper, 2);
     size_t n_bytes = ((n_bits - 1) / 8) + 1;
-    uint8_t *rand_bytes = (uint8_t *) malloc(n_bytes * sizeof(uint8_t));
+    uint8_t *rand_bytes = (uint8_t *) cfe_malloc(n_bytes * sizeof(uint8_t));
 
     // calculate max unsigned number that we can represent with the given
     // number of bits


### PR DESCRIPTION
This PR introduces a function which wraps `malloc` and aborts if an error is detected. This way of handling `malloc`'s errors is a bit crude compared to returning an error code, but it avoids undefined behaviour.